### PR TITLE
feat: Emit OTLP telemetry directly instead of via Honeycomb

### DIFF
--- a/src/utils/span.ts
+++ b/src/utils/span.ts
@@ -10,10 +10,7 @@ import { Attributes, Span, trace, context as otelcontext } from '@opentelemetry/
 import { URL } from "url"
 
 const traceExporter = new OTLPTraceExporter({
-    url: "https://refinery.sierrasoftworks.com/v1/traces",
-    headers: {
-        "x-honeycomb-team": process.env.HONEYCOMB_KEY
-    },
+    url: "https://telemetry.sierrasoftworks.com/v1/traces",
     timeoutMillis: 500,
 });
 


### PR DESCRIPTION
Switches telemetry away from Honeycomb (via the Refinery proxy) to plain OpenTelemetry OTLP emission.

- Repoint the OTLP trace exporter to https://telemetry.sierrasoftworks.com/v1/traces
- Drop the Honeycomb-specific x-honeycomb-team header and HONEYCOMB_KEY env dependency

No dependency changes required (exporter-trace-otlp-proto is already generic OTLP). HONEYCOMB_KEY can be removed from the Azure Function app settings once deployed.